### PR TITLE
Pull in changes from different forks for Ruby 3.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ class Vehicle
   # transitions defined from the source above
   def machine
     vehicle = self
-    @machine ||= Machine.new(vehicle, :initial => :parked, :action => :save) do
+    @machine ||= Machine.new(Vehicle, :initial => :parked, :action => :save) do
       vehicle.transitions.each {|attrs| transition(attrs)}
     end
   end

--- a/README.md
+++ b/README.md
@@ -990,6 +990,22 @@ file to load:
 gem 'state_machine', :require => 'state_machine/core'
 ```
 
+### Translation (Internationalization)
+
+Add to your locale file, for example: config/locales/en.yml
+
+```
+en:
+  activerecord:
+    state_machines:
+      vehicle:
+        states:
+          parked: On parking
+        events:
+          ignite: Start engine
+```
+
+
 ## Tools
 
 ### Generating graphs

--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -382,7 +382,7 @@ module StateMachine
           end
           
           default_options = default_error_message_options(object, attribute, message)
-          object.errors.add(attribute, message, options.merge(default_options))
+          object.errors.add(attribute, message, **options.merge(default_options))
         end
       end
       

--- a/lib/state_machine/integrations/active_model.rb
+++ b/lib/state_machine/integrations/active_model.rb
@@ -397,6 +397,11 @@ module StateMachine
         object.errors.clear if supports_validations?
       end
       
+      # Runs state events around the object's validation process
+      def around_validation(object)
+        object.class.state_machines.transitions(object, action, :after => false).perform { yield }
+      end
+
       protected
         # Whether observers are supported in the integration.  Only true if
         # ActiveModel::Observer is available.
@@ -507,11 +512,6 @@ module StateMachine
         # :validation event
         def define_validation_hook
           owner_class.set_callback(:validation, :around, self, :prepend => true)
-        end
-        
-        # Runs state events around the object's validation process
-        def around_validation(object)
-          object.class.state_machines.transitions(object, action, :after => false).perform { yield }
         end
         
         # Creates a new callback in the callback chain, always inserting it

--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -35,6 +35,10 @@ module StateMachine
     #   vehicle.ignite                    # => true
     #   vehicle.reload                    # => #<Vehicle id: 1, name: "Ford Explorer", state: "idling">
     # 
+    # *Note* that if you want a transition to update additional attributes of the record, 
+    # either the changes need to be made in a +before_transition+ callback or you need 
+    # to save the record manually.
+    #
     # == Events
     # 
     # As described in StateMachine::InstanceMethods#state_machine, event

--- a/lib/state_machine/integrations/active_record.rb
+++ b/lib/state_machine/integrations/active_record.rb
@@ -472,7 +472,7 @@ module StateMachine
           define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
             def initialize(*)
               super do |*args|
-                self.class.state_machines.initialize_states(self, :static => false)
+                self.class.state_machines.initialize_states(self)
                 yield(*args) if block_given?
               end
             end

--- a/lib/state_machine/integrations/base.rb
+++ b/lib/state_machine/integrations/base.rb
@@ -78,7 +78,7 @@ module StateMachine
         # support i18n.
         def locale_path
           path = "#{File.dirname(__FILE__)}/#{integration_name}/locale.rb"
-          path if File.exists?(path)
+          path if File.exist?(path)
         end
         
         # Extends the given object with any version overrides that are currently

--- a/lib/state_machine/integrations/mongoid.rb
+++ b/lib/state_machine/integrations/mongoid.rb
@@ -425,7 +425,11 @@ module StateMachine
               def update(*)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end
-              
+
+              def update_document(*)
+                self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
+              end
+
               def upsert(*)
                 self.class.state_machine(#{name.inspect}).send(:around_save, self) { super }
               end

--- a/lib/state_machine/machine.rb
+++ b/lib/state_machine/machine.rb
@@ -568,7 +568,6 @@ module StateMachine
       @initialize_state = options[:initialize]
       @action_hook_defined = false
       self.owner_class = owner_class
-      self.initial_state = options[:initial] unless sibling_machines.any?
       
       # Merge with sibling machine configurations
       add_sibling_machine_configs
@@ -580,6 +579,7 @@ module StateMachine
       
       # Evaluate DSL
       instance_eval(&block) if block_given?
+      self.initial_state = options[:initial] unless sibling_machines.any?
     end
     
     # Creates a copy of this machine in addition to copies of each associated

--- a/test/unit/machine_test.rb
+++ b/test/unit/machine_test.rb
@@ -328,6 +328,30 @@ class MachineWithStaticInitialStateTest < Test::Unit::TestCase
   end
 end
 
+class MachineWithInitialStateWithValueAndOwnerDefault < Test::Unit::TestCase
+  def setup
+    @original_stderr, $stderr = $stderr, StringIO.new
+    
+    state_machine_with_defaults = Class.new(StateMachine::Machine) do
+      def owner_class_attribute_default
+        0
+      end
+    end
+    @klass = Class.new
+    @machine = state_machine_with_defaults.new(@klass, :initial => :parked) do
+      state :parked, :value => 0
+    end
+  end
+  
+  def test_should_not_warn_about_wrong_default
+    assert_equal '', $stderr.string
+  end
+  
+  def teardown
+    $stderr = @original_stderr
+  end
+end
+
 class MachineWithDynamicInitialStateTest < Test::Unit::TestCase
   def setup
     @klass = Class.new do


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_

[Ink of the week](https://github.com/customink/ink-of-the-week/) uses a gem [pluginaweek/state_machine](https://github.com/pluginaweek/state_machine) that has not been updated in 11 years and is not compatible with Ruby 3.1.

The contractors we hired last year created [a fork](https://github.com/sumirolabs/state_machine) based on [another fork](https://github.com/seuros/state_machine) to make it compatible.

This PR pulls in the updates from two different forked repos that make gem compatible with Ruby 3.1 into our own fork

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
_[Replace this with a description of the risk, if any, and how the change will be deployed.]_

- ✅ Negligible risk!

### Changes

There are two different commits that pull in the updates from two different forks

1. First 13 commits are pulled in from https://github.com/seuros/state_machine
2. The last commit pulls the updates from https://github.com/sumirolabs/state_machine/tree/ruby_3.1_upgrade


### What GIF Best Describes This Pull Request?

![](https://media3.giphy.com/media/NnrvuFZr0uZFM49iZy/giphy.gif)
